### PR TITLE
CDN: add more configurable options

### DIFF
--- a/cdn/main.tf
+++ b/cdn/main.tf
@@ -1,5 +1,7 @@
+# CDN Profile
+
 resource "azurerm_cdn_profile" "this" {
-  name = var.cdn_profile_name
+  name = "${var.name}-cdn-profile"
 
   location            = var.location
   resource_group_name = var.resource_group_name
@@ -9,21 +11,28 @@ resource "azurerm_cdn_profile" "this" {
   tags = var.tags
 }
 
+# CDN Endpoint
+
 resource "azurerm_cdn_endpoint" "this" {
-  name = var.cdn_endpoint_name
+  name = "${var.name}-cdn-endpoint"
 
   location            = var.location
   resource_group_name = var.resource_group_name
 
   is_http_allowed = var.is_http_allowed
-  profile_name    = azurerm_cdn_profile.this.name
 
-  origin {
-    host_name = var.host_name
-    name      = var.cdn_endpoint_name
-  }
-
+  optimization_type  = var.optimization_type
   origin_host_header = var.host_name
+  profile_name       = azurerm_cdn_profile.this.name
+
+  querystring_caching_behaviour = var.querystring_caching_behaviour
 
   tags = var.tags
+
+  origin {
+    name = var.name
+
+    host_name  = var.host_name
+    https_port = var.https_port
+  }
 }

--- a/cdn/variables.tf
+++ b/cdn/variables.tf
@@ -1,13 +1,11 @@
-variable "cdn_endpoint_name" {
-  type = string
-}
-
-variable "cdn_profile_name" {
-  type = string
-}
-
 variable "host_name" {
   type = string
+}
+
+variable "https_port" {
+  type = string
+
+  default = "443"
 }
 
 variable "is_http_allowed" {
@@ -18,6 +16,22 @@ variable "is_http_allowed" {
 
 variable "location" {
   type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "optimization_type" {
+  type = string
+
+  default = "GeneralWebDelivery"
+}
+
+variable "querystring_caching_behaviour" {
+  type = bool
+
+  default = "IgnoreQueryString"
 }
 
 variable "resource_group_name" {


### PR DESCRIPTION
#### Changes:
- more configurable options for CDN
- add common `name` option instead of `cdn_profile_name ` and `cdn_endpoint_name`